### PR TITLE
[Changelog CI] Add Changelog for Version 1.0.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,7 @@
+Version: 1.0.0
+==============
+
+* `9e53c86 <https://github.com/entr0phy4/mind_palace/commit/9e53c86493c2bbe39a33cd6381cb62c7bd50818f>`__: ci: Update changelog workflow
+* `100b186 <https://github.com/entr0phy4/mind_palace/commit/100b186a119faa1f57121857f144a432b790f4fc>`__: ci: Use GH_TOKEN secret for changelog workflow
+* `ce93485 <https://github.com/entr0phy4/mind_palace/commit/ce93485281c4614a17867b3fecdceca8d2daef77>`__: ci: Add changelog CI workflow and config
+* `6c307d8 <https://github.com/entr0phy4/mind_palace/commit/6c307d8fa64e4adf582f011b899b282ae7bff10d>`__: ci: Remove build step from release workflow


### PR DESCRIPTION
# Version: 1.0.0

* [9e53c86](https://github.com/entr0phy4/mind_palace/commit/9e53c86493c2bbe39a33cd6381cb62c7bd50818f): ci: Update changelog workflow
* [100b186](https://github.com/entr0phy4/mind_palace/commit/100b186a119faa1f57121857f144a432b790f4fc): ci: Use GH_TOKEN secret for changelog workflow
* [ce93485](https://github.com/entr0phy4/mind_palace/commit/ce93485281c4614a17867b3fecdceca8d2daef77): ci: Add changelog CI workflow and config
* [6c307d8](https://github.com/entr0phy4/mind_palace/commit/6c307d8fa64e4adf582f011b899b282ae7bff10d): ci: Remove build step from release workflow
